### PR TITLE
Allow using personal access token to authenticate with github

### DIFF
--- a/server/resources/feature.jsp
+++ b/server/resources/feature.jsp
@@ -1,4 +1,4 @@
-<%@ include file="/include-internal.jsp"%>
+<%@ include file="/include-internal.jsp" %>
 <%@ taglib prefix="props" tagdir="/WEB-INF/tags/props" %>
 <%--
   ~ Copyright 2000-2012 JetBrains s.r.o.
@@ -22,19 +22,20 @@
   <td colspan="2">Specify GitHub repository name and credentials to push status updates to</td>
 </tr>
 <l:settingsGroup title="Main">
-<tr>
-  <th>URL:<l:star/></th>
-  <td>
-    <props:textProperty name="${keys.serverKey}" className="longField"/>
-    <span class="error" id="error_${keys.serverKey}"></span>
+  <tr>
+    <th>URL:<l:star/></th>
+    <td>
+      <props:textProperty name="${keys.serverKey}" className="longField"/>
+      <span class="error" id="error_${keys.serverKey}"></span>
     <span class="smallNote">
       Specify GitHub instance URL.
       <br/>
       Use <strong>http(s)://[hostname]/api/v3</strong>
-      for <a href="https://support.enterprise.github.com/entries/21391237-Using-the-API" target="_blank">GitHub Enterprise</a>
+      for <a href="https://support.enterprise.github.com/entries/21391237-Using-the-API" target="_blank">GitHub
+      Enterprise</a>
     </span>
-  </td>
-</tr>
+    </td>
+  </tr>
 
 
   <tr>
@@ -51,6 +52,16 @@
 
 <l:settingsGroup title="Authentication">
   <tr>
+    <th>Authentication Type</th>
+    <td>
+      <props:selectProperty name="${keys.authenticationTypeKey}" id="authenticationType">
+        <props:option value="PASSWORD_AUTH">Password</props:option>
+        <props:option value="TOKEN_AUTH">Personal Access Token</props:option>
+      </props:selectProperty>
+    </td>
+  </tr>
+
+  <tr id="authUsernameRow">
     <th>User Name:<l:star/></th>
     <td>
       <props:textProperty name="${keys.userNameKey}" className="longField"/>
@@ -58,7 +69,7 @@
       <span class="smallNote">Specify GitHub user name</span>
     </td>
   </tr>
-  <tr>
+  <tr id="authPasswordRow">
     <th>Password:<l:star/></th>
     <td>
       <props:passwordProperty name="${keys.passwordKey}" className="longField"/>
@@ -66,13 +77,13 @@
       <span class="smallNote">Specify GitHub password</span>
     </td>
   </tr>
-  <tr>
+
+  <tr id="authTokenRow">
     <th>Personal Access Token:</th>
     <td>
       <props:passwordProperty name="${keys.accessTokenKey}" className="longField"/>
       <span class="error" id="error_${keys.accessTokenKey}"></span>
       <span class="smallNote">Specify Access Token      </span>
-        If a token is specified, it will be used instead of the username and password above.
 
     </td>
   </tr>
@@ -85,25 +96,46 @@
     <div class="attentionComment">
       TeamCity Server URL<bs:help file="Configuring+Server+URL"/> will be used in GitHub status.
       Make sure this URL is specified correctly. To change it use
-      <a href="<c:url value='/admin/admin.html?item=serverConfigGeneral'/>" target="_blank">Server Configuration page</a>.
+      <a href="<c:url value='/admin/admin.html?item=serverConfigGeneral'/>" target="_blank">Server Configuration
+        page</a>.
     </div>
   </td>
 </tr>
 <l:settingsGroup title="Repository">
-<tr>
-  <th>Owner:<l:star/></th>
-  <td>
-    <props:textProperty name="${keys.repositoryOwnerKey}" className="longField"/>
-    <span class="error" id="error_${keys.repositoryOwnerKey}"></span>
-    <span class="smallNote">Specify GitHub repository owner name (user or organization)</span>
-  </td>
-</tr>
-<tr>
-  <th>Repository:<l:star/></th>
-  <td>
-    <props:textProperty name="${keys.repositoryNameKey}" className="longField"/>
-    <span class="error" id="error_${keys.repositoryNameKey}"></span>
-    <span class="smallNote">Specify GitHub repository name to push change statuses to</span>
-  </td>
-</tr>
+  <tr>
+    <th>Owner:<l:star/></th>
+    <td>
+      <props:textProperty name="${keys.repositoryOwnerKey}" className="longField"/>
+      <span class="error" id="error_${keys.repositoryOwnerKey}"></span>
+      <span class="smallNote">Specify GitHub repository owner name (user or organization)</span>
+    </td>
+  </tr>
+  <tr>
+    <th>Repository:<l:star/></th>
+    <td>
+      <props:textProperty name="${keys.repositoryNameKey}" className="longField"/>
+      <span class="error" id="error_${keys.repositoryNameKey}"></span>
+      <span class="smallNote">Specify GitHub repository name to push change statuses to</span>
+    </td>
+  </tr>
 </l:settingsGroup>
+
+
+<script type="text/javascript">
+  (function () {
+    var update = function () {
+      var authType = $j("#authenticationType").val();
+      if (authType == "PASSWORD_AUTH") {
+        BS.Util.hide('authTokenRow');
+        BS.Util.show('authUsernameRow','authPasswordRow');
+      }
+      if (authType == "TOKEN_AUTH") {
+        BS.Util.show('authTokenRow');
+        BS.Util.hide('authUsernameRow','authPasswordRow');
+      }
+    };
+
+    $j("#authenticationType").change(update);
+    $j(document).ready(update);
+  })();
+</script>

--- a/server/src/jetbrains/teamcilty/github/ChangeStatusUpdater.java
+++ b/server/src/jetbrains/teamcilty/github/ChangeStatusUpdater.java
@@ -22,9 +22,9 @@ import jetbrains.buildServer.serverSide.*;
 import jetbrains.buildServer.serverSide.executors.ExecutorServices;
 import jetbrains.buildServer.util.ExceptionUtil;
 import jetbrains.buildServer.util.StringUtil;
-import jetbrains.teamcilty.github.api.GitHubApi;
-import jetbrains.teamcilty.github.api.GitHubApiFactory;
-import jetbrains.teamcilty.github.api.GitHubChangeState;
+import jetbrains.teamcilty.github.api.*;
+import jetbrains.teamcilty.github.api.impl.GitHubApiPasswordAuthentication;
+import jetbrains.teamcilty.github.api.impl.GitHubApiTokenAuthentication;
 import jetbrains.teamcilty.github.ui.UpdateChangeStatusFeature;
 import jetbrains.teamcilty.github.ui.UpdateChangesConstants;
 import jetbrains.teamcilty.github.util.LoggerHelper;
@@ -121,7 +121,7 @@ public class ChangeStatusUpdater {
     long second = seconds % 60;
     long minute = (seconds / 60) % 60;
     long hour = seconds / 60 / 60;
-    
+
     return String.format("%02d:%02d:%02d", hour, minute, second);
   }
 
@@ -144,21 +144,24 @@ public class ChangeStatusUpdater {
 
     final UpdateChangesConstants c = new UpdateChangesConstants();
 
-    // With github, you can simply replace the username with an access token as long
-    // as you send an empty password.  That is what we do here, if an access token
-    // is defined.
+    GitHubApiAuthenticationType authenticationType = GitHubApiAuthenticationType.valueOf(feature.getParameters().get(c.getAuthenticationTypeKey()));
+    GitHubApiAuthentication apiAuthentication = null;
 
-    String password = feature.getParameters().get(c.getPasswordKey());
-    String userOrAcessToken = feature.getParameters().get(c.getUserNameKey());
-    if (feature.getParameters().get(c.getAccessTokenKey()) != null) {
-      userOrAcessToken = feature.getParameters().get(c.getAccessTokenKey());
-      password = "";
+    switch (authenticationType) {
+      case PASSWORD_AUTH:
+        String username = feature.getParameters().get(c.getUserNameKey());
+        String password = feature.getParameters().get(c.getPasswordKey());
+        apiAuthentication = new GitHubApiPasswordAuthentication(username, password);
+      case TOKEN_AUTH:
+        String token = feature.getParameters().get(c.getAccessTokenKey());
+        apiAuthentication = new GitHubApiTokenAuthentication(token);
     }
 
     final GitHubApi api = myFactory.openGitHub(
             feature.getParameters().get(c.getServerKey()),
-            userOrAcessToken,
-            password);
+            apiAuthentication
+    );
+
     final String repositoryOwner = feature.getParameters().get(c.getRepositoryOwnerKey());
     final String repositoryName = feature.getParameters().get(c.getRepositoryNameKey());
     final boolean addComments = !StringUtil.isEmptyOrSpaces(feature.getParameters().get(c.getUseCommentsKey()));

--- a/server/src/jetbrains/teamcilty/github/api/GitHubApiAuthentication.java
+++ b/server/src/jetbrains/teamcilty/github/api/GitHubApiAuthentication.java
@@ -1,0 +1,7 @@
+package jetbrains.teamcilty.github.api;
+
+import org.apache.http.auth.Credentials;
+
+public interface GitHubApiAuthentication {
+  Credentials buildCredentials();
+}

--- a/server/src/jetbrains/teamcilty/github/api/GitHubApiAuthenticationType.java
+++ b/server/src/jetbrains/teamcilty/github/api/GitHubApiAuthenticationType.java
@@ -1,0 +1,5 @@
+package jetbrains.teamcilty.github.api;
+
+public enum GitHubApiAuthenticationType {
+  TOKEN_AUTH, PASSWORD_AUTH
+}

--- a/server/src/jetbrains/teamcilty/github/api/GitHubApiFactory.java
+++ b/server/src/jetbrains/teamcilty/github/api/GitHubApiFactory.java
@@ -26,7 +26,5 @@ public interface GitHubApiFactory {
   public static final String DEFAULT_URL = "https://api.github.com";
 
   @NotNull
-  GitHubApi openGitHub(@NotNull final String url,
-                       @NotNull final String username,
-                       final String password);
+  GitHubApi openGitHub(@NotNull final String url, @NotNull final GitHubApiAuthentication gitHubApiAuthentication);
 }

--- a/server/src/jetbrains/teamcilty/github/api/impl/GitHubApiFactoryImpl.java
+++ b/server/src/jetbrains/teamcilty/github/api/impl/GitHubApiFactoryImpl.java
@@ -17,6 +17,7 @@
 package jetbrains.teamcilty.github.api.impl;
 
 import jetbrains.teamcilty.github.api.GitHubApi;
+import jetbrains.teamcilty.github.api.GitHubApiAuthentication;
 import jetbrains.teamcilty.github.api.GitHubApiFactory;
 import org.jetbrains.annotations.NotNull;
 
@@ -32,7 +33,7 @@ public class GitHubApiFactoryImpl implements GitHubApiFactory {
   }
 
   @NotNull
-  public GitHubApi openGitHub(@NotNull String url, @NotNull String username, String password) {
-    return new GitHubApiImpl(myWrapper, new GitHubApiPaths(url), username, password);
+  public GitHubApi openGitHub(@NotNull String url, @NotNull GitHubApiAuthentication gitHubApiAuthentication) {
+    return new GitHubApiImpl(myWrapper, new GitHubApiPaths(url), gitHubApiAuthentication);
   }
 }

--- a/server/src/jetbrains/teamcilty/github/api/impl/GitHubApiImpl.java
+++ b/server/src/jetbrains/teamcilty/github/api/impl/GitHubApiImpl.java
@@ -20,6 +20,7 @@ import com.google.gson.Gson;
 import com.intellij.openapi.diagnostic.Logger;
 import jetbrains.buildServer.util.FileUtil;
 import jetbrains.teamcilty.github.api.GitHubApi;
+import jetbrains.teamcilty.github.api.GitHubApiAuthentication;
 import jetbrains.teamcilty.github.api.GitHubChangeState;
 import jetbrains.teamcilty.github.api.impl.data.*;
 import jetbrains.teamcilty.github.util.LoggerHelper;
@@ -61,21 +62,15 @@ public class GitHubApiImpl implements GitHubApi {
   private final HttpClientWrapper myClient;
   private final Gson myGson = new Gson();
   private final GitHubApiPaths myUrls;
-  private final String myUserName;
-  private final String myPassword;
+  private GitHubApiAuthentication myGitHubApiAuthentication;
 
   public GitHubApiImpl(@NotNull final HttpClientWrapper client,
                        @NotNull final GitHubApiPaths urls,
-                       @NotNull final String userName,
-                       final String password) {
+                       @NotNull final GitHubApiAuthentication gitHubApiAuthentication
+  ) {
     myClient = client;
     myUrls = urls;
-    myUserName = userName;
-    if (null == password) {
-      myPassword = "";
-    } else {
-      myPassword = password;
-    }
+    myGitHubApiAuthentication = gitHubApiAuthentication;
   }
 
   @Nullable
@@ -228,7 +223,7 @@ public class GitHubApiImpl implements GitHubApi {
 
   private void includeAuthentication(@NotNull HttpRequest request) throws IOException {
     try {
-      request.addHeader(new BasicScheme().authenticate(new UsernamePasswordCredentials(myUserName, myPassword), request));
+      request.addHeader(new BasicScheme().authenticate(myGitHubApiAuthentication.buildCredentials(), request));
     } catch (AuthenticationException e) {
       throw new IOException("Failed to set authentication for request. " + e.getMessage(), e);
     }

--- a/server/src/jetbrains/teamcilty/github/api/impl/GitHubApiPasswordAuthentication.java
+++ b/server/src/jetbrains/teamcilty/github/api/impl/GitHubApiPasswordAuthentication.java
@@ -1,0 +1,18 @@
+package jetbrains.teamcilty.github.api.impl;
+
+import jetbrains.teamcilty.github.api.GitHubApiAuthentication;
+import org.apache.http.auth.UsernamePasswordCredentials;
+
+public class GitHubApiPasswordAuthentication implements GitHubApiAuthentication {
+  private final String myUsername;
+  private final String myPassword;
+
+  public GitHubApiPasswordAuthentication(String username, String password) {
+    myUsername = username;
+    myPassword = password;
+  }
+
+  public UsernamePasswordCredentials buildCredentials() {
+    return new UsernamePasswordCredentials(myUsername, myPassword);
+  }
+}

--- a/server/src/jetbrains/teamcilty/github/api/impl/GitHubApiTokenAuthentication.java
+++ b/server/src/jetbrains/teamcilty/github/api/impl/GitHubApiTokenAuthentication.java
@@ -1,0 +1,16 @@
+package jetbrains.teamcilty.github.api.impl;
+
+import jetbrains.teamcilty.github.api.GitHubApiAuthentication;
+import org.apache.http.auth.UsernamePasswordCredentials;
+
+public class GitHubApiTokenAuthentication implements GitHubApiAuthentication {
+  private final String myToken;
+
+  public GitHubApiTokenAuthentication(String token) {
+    myToken = token;
+  }
+
+  public UsernamePasswordCredentials buildCredentials() {
+    return new UsernamePasswordCredentials(myToken, "x-oauth-basic");
+  }
+}

--- a/server/src/jetbrains/teamcilty/github/ui/UpdateChangeStatusFeature.java
+++ b/server/src/jetbrains/teamcilty/github/ui/UpdateChangeStatusFeature.java
@@ -21,6 +21,7 @@ import jetbrains.buildServer.serverSide.BuildFeature;
 import jetbrains.buildServer.serverSide.InvalidProperty;
 import jetbrains.buildServer.serverSide.PropertiesProcessor;
 import jetbrains.buildServer.util.StringUtil;
+import jetbrains.teamcilty.github.api.GitHubApiAuthenticationType;
 import jetbrains.teamcilty.github.api.GitHubApiFactory;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -92,11 +93,14 @@ public class UpdateChangeStatusFeature extends BuildFeature {
         final Collection<InvalidProperty> result = new ArrayList<InvalidProperty>();
         if (p == null) return result;
 
-        //We only want to make sure username and password are set if an access token isn't set
-
-        if (isEmpty(p, c.getAccessTokenKey())) {
+        GitHubApiAuthenticationType authenticationType = GitHubApiAuthenticationType.valueOf(p.get(c.getAuthenticationTypeKey()));
+        if (authenticationType == GitHubApiAuthenticationType.PASSWORD_AUTH) {
           checkNotEmpty(p, c.getUserNameKey(), "Username must be specified", result);
           checkNotEmpty(p, c.getPasswordKey(), "Password must be specified", result);
+        }
+
+        if (authenticationType == GitHubApiAuthenticationType.TOKEN_AUTH) {
+          checkNotEmpty(p, c.getAccessTokenKey(), "Personal Access Token must be specified", result);
         }
 
         checkNotEmpty(p, c.getRepositoryNameKey(), "Repository name must be specified", result);

--- a/server/src/jetbrains/teamcilty/github/ui/UpdateChangesConstants.java
+++ b/server/src/jetbrains/teamcilty/github/ui/UpdateChangesConstants.java
@@ -30,4 +30,5 @@ public class UpdateChangesConstants {
   public String getRepositoryOwnerKey() { return "guthub_owner"; }
   public String getUseCommentsKey() { return "guthub_comments"; }
   public String getAccessTokenKey() { return Constants.SECURE_PROPERTY_PREFIX +"github_access_token"; }
+  public String getAuthenticationTypeKey() { return "guthub_authentication_type";}
 }

--- a/tests/src/GitHubApiTest.java
+++ b/tests/src/GitHubApiTest.java
@@ -20,9 +20,7 @@ import jetbrains.buildServer.util.PropertiesUtil;
 import jetbrains.buildServer.util.StringUtil;
 import jetbrains.teamcilty.github.api.GitHubApi;
 import jetbrains.teamcilty.github.api.GitHubChangeState;
-import jetbrains.teamcilty.github.api.impl.GitHubApiImpl;
-import jetbrains.teamcilty.github.api.impl.GitHubApiPaths;
-import jetbrains.teamcilty.github.api.impl.HttpClientWrapperImpl;
+import jetbrains.teamcilty.github.api.impl.*;
 import org.apache.http.auth.AuthenticationException;
 import org.jetbrains.annotations.NotNull;
 import org.testng.Assert;
@@ -66,16 +64,13 @@ public class GitHubApiTest extends BaseTestCase {
     myApi = new GitHubApiImpl(
             new HttpClientWrapperImpl(),
             new GitHubApiPaths(ps.getProperty(URL)),
-            user,
-            rewind(ps.getProperty(PASSWORD_REV)));
-
-    System.out.println("about to use access token: " + ps.getProperty(ACCESS_TOKEN));
+            new GitHubApiPasswordAuthentication(user, rewind(ps.getProperty(PASSWORD_REV)))
+    );
 
     accessTokenApi = new GitHubApiImpl(
             new HttpClientWrapperImpl(),
             new GitHubApiPaths(ps.getProperty(URL)),
-            ps.getProperty(ACCESS_TOKEN),
-            null);
+            new GitHubApiTokenAuthentication(ps.getProperty(ACCESS_TOKEN)));
 
     myPrCommit = ps.getProperty(PR_COMMIT);
   }


### PR DESCRIPTION
This adds the option to use a github personal access token instead of username/password to authenticate with the github api.

Before the new test will pass, you need to generate a token and add it [here](https://github.com/willroden/TeamCity.GitHub/blob/772767a10b9ffc26b1eb6766911aaeaf2697c888/tests/src/GitHubApiTest.java#L114).
