### PR TITLE
Sets default URL to https://api.github.com/

### DIFF
--- a/server/resources/feature.jsp
+++ b/server/resources/feature.jsp
@@ -25,7 +25,7 @@
   <tr>
     <th>URL:<l:star/></th>
     <td>
-      <props:textProperty name="${keys.serverKey}" className="longField"/>
+      <props:textProperty name="${keys.serverKey}" className="longField" value="https://api.github.com/"/>
       <span class="error" id="error_${keys.serverKey}"></span>
     <span class="smallNote">
       Specify GitHub instance URL.


### PR DESCRIPTION
Resolves issue #90