### PR TITLE
Do not update build status for personal builds

### DIFF
--- a/server/src/jetbrains/teamcilty/github/ChangeStatusListener.java
+++ b/server/src/jetbrains/teamcilty/github/ChangeStatusListener.java
@@ -62,6 +62,10 @@ public class ChangeStatusListener {
   private void updateBuildStatus(@NotNull final SRunningBuild build, boolean isStarting) {
     SBuildType bt = build.getBuildType();
     if (bt == null) return;
+    if (build.isPersonal()) {
+      LOG.debug("Skipping status update for personal build");
+      return;
+    }
 
     for (SBuildFeatureDescriptor feature : bt.getResolvedSettings().getBuildFeatures()) {
       if (!feature.getType().equals(UpdateChangeStatusFeature.FEATURE_TYPE)) continue;


### PR DESCRIPTION
When one triggers a personal build, the plugin will update build status for latest change on GitHub. This is not the desired behavior, I believe, as those builds are typically invoked for uncommitted changes, so status updates are not related to commits.