### PR TITLE
Make failed tests report details even if it isn't a stacktrace.

### DIFF
--- a/server/src/jetbrains/teamcilty/github/ChangeStatusUpdater.java
+++ b/server/src/jetbrains/teamcilty/github/ChangeStatusUpdater.java
@@ -162,14 +162,14 @@ public class ChangeStatusUpdater {
 
         myExecutor.submit(ExceptionUtil.catchAll("set change status on github", new Runnable() {
           @NotNull
-          private String getFailureText(@Nullable final TestFailureInfo failureInfo) {
+          private String getFailureText(@Nullable final STestRun testRun) {
             final String no_data = "<no details avaliable>";
             if (failureInfo == null) return no_data;
 
-            final String stacktrace = failureInfo.getShortStacktrace();
-            if (stacktrace == null || StringUtil.isEmptyOrSpaces(stacktrace)) return no_data;
+            final String details = testRun.getFullText();
+            if (details == null || StringUtil.isEmptyOrSpaces(details)) return no_data;
 
-            return stacktrace;
+            return details;
           }
 
           @NotNull
@@ -225,7 +225,7 @@ public class ChangeStatusUpdater {
                     comment.append("");
                     comment.append(testRun.getTest().getName().toString());
                     comment.append(": ");
-                    comment.append(getFailureText(testRun.getFailureInfo()));
+                    comment.append(getFailureText(testRun));
                     comment.append("\n\n");
 
                     if (i == 10) {

--- a/server/src/jetbrains/teamcilty/github/ChangeStatusUpdater.java
+++ b/server/src/jetbrains/teamcilty/github/ChangeStatusUpdater.java
@@ -164,7 +164,7 @@ public class ChangeStatusUpdater {
           @NotNull
           private String getFailureText(@Nullable final STestRun testRun) {
             final String no_data = "<no details avaliable>";
-            if (failureInfo == null) return no_data;
+            if (testRun == null) return no_data;
 
             final String details = testRun.getFullText();
             if (details == null || StringUtil.isEmptyOrSpaces(details)) return no_data;


### PR DESCRIPTION
As of right now, when tests fail without throwing an exception, I just see this in GitHub:

```
Failed tests

PR Tests: file overlap: <no details avaliable>
```

This updates the status updater to report details of the failed test, even when the failure isn't due to an exception/stacktrace.
