### PR TITLE
Revert "Issue#21 :Marking the build as pending when added to queue"

### DIFF
--- a/server/src/jetbrains/teamcilty/github/ChangeStatusListener.java
+++ b/server/src/jetbrains/teamcilty/github/ChangeStatusListener.java
@@ -42,10 +42,9 @@ public class ChangeStatusListener {
                               @NotNull final ChangeStatusUpdater updater) {
     myUpdater = updater;
     listener.addListener(new BuildServerAdapter(){
-
       @Override
-      public void buildTypeAddedToQueue(@NotNull SBuildType buildType) {
-        updateBuildStatus(buildType.getLastChangesStartedBuild(), true);
+      public void changesLoaded(@NotNull final SRunningBuild build) {
+        updateBuildStatus(build, true);
       }
 
       @Override
@@ -60,7 +59,7 @@ public class ChangeStatusListener {
     });
   }
 
-  private void updateBuildStatus(@NotNull final SBuild build, boolean isStarting) {
+  private void updateBuildStatus(@NotNull final SRunningBuild build, boolean isStarting) {
     SBuildType bt = build.getBuildType();
     if (bt == null) return;
     if (build.isPersonal()) {
@@ -91,7 +90,7 @@ public class ChangeStatusListener {
   }
 
   @NotNull
-  private Collection<BuildRevision> getLatestChangesHash(@NotNull final SBuild build) {
+  private Collection<BuildRevision> getLatestChangesHash(@NotNull final SRunningBuild build) {
     final Collection<BuildRevision> result = new ArrayList<BuildRevision>();
     for (BuildRevision rev : build.getRevisions()) {
       if (!"jetbrains.git".equals(rev.getRoot().getVcsName())) continue;

--- a/server/src/jetbrains/teamcilty/github/ChangeStatusUpdater.java
+++ b/server/src/jetbrains/teamcilty/github/ChangeStatusUpdater.java
@@ -97,7 +97,7 @@ public class ChangeStatusUpdater {
 
     return new Handler() {
       @NotNull
-      private String getViewResultsUrl(@NotNull final SBuild build) {
+      private String getViewResultsUrl(@NotNull final SRunningBuild build) {
         final String url = myWeb.getViewResultsUrl(build);
         if (useGuestUrls) {
           return url + (url.contains("?") ? "&" : "?") + "guest=1";
@@ -113,11 +113,11 @@ public class ChangeStatusUpdater {
         return shouldReportOnFinish;
       }
 
-      public void scheduleChangeStarted(@NotNull RepositoryVersion version, @NotNull SBuild build) {
+      public void scheduleChangeStarted(@NotNull RepositoryVersion version, @NotNull SRunningBuild build) {
         scheduleChangeUpdate(version, build, "Started TeamCity Build " + build.getFullName(), GitHubChangeState.Pending);
       }
 
-      public void scheduleChangeCompeted(@NotNull RepositoryVersion version, @NotNull SBuild build) {
+      public void scheduleChangeCompeted(@NotNull RepositoryVersion version, @NotNull SRunningBuild build) {
         LOG.debug("Status :" + build.getStatusDescriptor().getStatus().getText());
         LOG.debug("Status Priority:" + build.getStatusDescriptor().getStatus().getPriority());
 
@@ -127,7 +127,7 @@ public class ChangeStatusUpdater {
       }
 
       @NotNull
-      private String getGitHubChangeText(@NotNull final SBuild build) {
+      private String getGitHubChangeText(@NotNull final SRunningBuild build) {
         final String text = build.getStatusDescriptor().getText();
         if (text != null) {
           return ": " + text;
@@ -137,7 +137,7 @@ public class ChangeStatusUpdater {
       }
 
       @NotNull
-      private GitHubChangeState getGitHubChangeState(@NotNull final SBuild build) {
+      private GitHubChangeState getGitHubChangeState(@NotNull final SRunningBuild build) {
         final Status status = build.getStatusDescriptor().getStatus();
         final byte priority = status.getPriority();
 
@@ -151,7 +151,7 @@ public class ChangeStatusUpdater {
       }
 
       private void scheduleChangeUpdate(@NotNull final RepositoryVersion version,
-                                        @NotNull final SBuild build,
+                                        @NotNull final SRunningBuild build,
                                         @NotNull final String message,
                                         @NotNull final GitHubChangeState status) {
         LOG.info("Scheduling GitHub status update for " +
@@ -183,7 +183,7 @@ public class ChangeStatusUpdater {
 
           @NotNull
           private String getComment(@NotNull RepositoryVersion version,
-                                    @NotNull SBuild build,
+                                    @NotNull SRunningBuild build,
                                     boolean completed,
                                     @NotNull String hash) {
             final StringBuilder comment = new StringBuilder();
@@ -304,7 +304,7 @@ public class ChangeStatusUpdater {
   public static interface Handler {
     boolean shouldReportOnStart();
     boolean shouldReportOnFinish();
-    void scheduleChangeStarted(@NotNull final RepositoryVersion hash, @NotNull final SBuild build);
-    void scheduleChangeCompeted(@NotNull final RepositoryVersion hash, @NotNull final SBuild build);
+    void scheduleChangeStarted(@NotNull final RepositoryVersion hash, @NotNull final SRunningBuild build);
+    void scheduleChangeCompeted(@NotNull final RepositoryVersion hash, @NotNull final SRunningBuild build);
   }
 }


### PR DESCRIPTION
Reverts jonnyzzz/TeamCity.GitHub#112

In this pr i have changed the event used for marking a build as pending :
public void changesLoaded(@NotNull final SRunningBuild build)
to the following one :
public void buildTypeAddedToQueue(@NotNull SBuildType buildType)

And all needed data i get form this object :
buildType.getLastChangesStartedBuild() since i don`t have a SRunningBuild object param and we need all information regarding the revisions, changes that triggered the build

Do you think this is correct ?

